### PR TITLE
:ambulance: Fix -Wzero-as-null-pointer-constant warning

### DIFF
--- a/libuavcan/CMakeLists.txt
+++ b/libuavcan/CMakeLists.txt
@@ -145,7 +145,7 @@ if (DEBUG_BUILD)
     if (COMPILER_IS_GCC_COMPATIBLE)
         # No such thing as too many warnings
         set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -Werror -pedantic -Wfloat-equal -Wconversion")
-        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wsign-conversion -Wcast-align -Wmissing-declarations -Wlogical-op")
+        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wsign-conversion -Wcast-align -Wmissing-declarations")
         set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wdouble-promotion -Wswitch-enum -Wtype-limits -Wno-error=array-bounds")
         set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wzero-as-null-pointer-constant -Wnon-virtual-dtor")
         set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Woverloaded-virtual -Wsign-promo -Wold-style-cast")
@@ -155,6 +155,7 @@ if (DEBUG_BUILD)
         message(STATUS "Compiler ID: ${CMAKE_CXX_COMPILER_ID}")
         message(FATAL_ERROR "This compiler cannot be used to build tests; use release build instead.")
     endif ()
+    add_compile_options($<$<CXX_COMPILER_ID:GNU>:-Wlogical-op>)
 
     # Additional flavours of the library
 

--- a/libuavcan/src/transport/uc_transfer_sender.cpp
+++ b/libuavcan/src/transport/uc_transfer_sender.cpp
@@ -83,7 +83,7 @@ int TransferSender::send(const uint8_t* payload, unsigned payload_len, Monotonic
             TransferCRC crc = crc_base_;
             crc.add(payload, payload_len);
 
-            static const int BUFLEN = sizeof(static_cast<CanFrame*>(0)->data);
+            static const int BUFLEN = sizeof(static_cast<CanFrame*>(nullptr)->data);
             uint8_t buf[BUFLEN];
 
             buf[0] = uint8_t(crc.get() & 0xFFU);       // Transfer CRC, little endian


### PR DESCRIPTION
```
    ../vendor/libuavcan/libuavcan/src/transport/uc_transfer_sender.cpp:86:69: error: zero as null pointer constant [-Werror,-Wzero-as-null-pointer-constant]
                static const int BUFLEN = sizeof(static_cast<CanFrame*>(0)->data);
                                                                        ^
                                                                        nullptr
```